### PR TITLE
Don't rely on specific server setup for some secrets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ poetry.lock
 __pycache__
 sitemap.json
 auth.json
-data/private_key.txt
-data/public_key.txt
 docs/build/
 docs/source/*.rst
 bundled/
+data/secrets

--- a/application/db/perms.py
+++ b/application/db/perms.py
@@ -99,7 +99,7 @@ def caller_info_strict() -> UserData | dict:
 	except exceptions.InvalidJWTError as e:
 		apikey: dict | None = apikeydb.find_one({'key': tok})
 		if apikey is None:
-			raise exceptions.AuthenticationError() from e
+			raise exceptions.JWTAuthenticationError() from e
 
 		return apikey
 

--- a/application/exceptions/__init__.py
+++ b/application/exceptions/__init__.py
@@ -46,6 +46,16 @@ class AuthenticationError(ClientError):
 		super().__init__(msg)
 
 
+class JWTAuthenticationError(ClientError):
+	"""Raised when authentication fails due to a JSON web token being invalid."""
+
+	def __init__(self) -> None:
+		"""
+		Initializes the exception with a message indicating that auth failed due to a bad JWT.
+		"""
+		super().__init__('Invalid JWT')
+
+
 class UserIsLocked(ClientError):
 	"""Raised when a user is locked."""
 

--- a/application/tokens.py
+++ b/application/tokens.py
@@ -2,7 +2,6 @@
 This module handles JWT token creation, decoding, and validation for user sessions and API keys.
 """
 
-import os
 import random
 from typing import Any
 
@@ -21,13 +20,14 @@ __public_key: Any = None
 def init() -> None:
 	"""
 	Initialize the JWT token system by loading the private and public keys.
+	If the keys don't exist, generate them first.
 	"""
 
 	global __private_key, __public_key
 
-	with open(os.environ['HOME'] + '/.ssh/id_rsa', 'r', encoding='utf8') as fp:
+	with open('data/secrets/id_rsa', 'r', encoding='utf8') as fp:
 		__private_key = serialization.load_ssh_private_key(fp.read().encode(), password=b'')
-	with open(os.environ['HOME'] + '/.ssh/id_rsa.pub', 'r', encoding='utf8') as fp:
+	with open('data/secrets/id_rsa.pub', 'r', encoding='utf8') as fp:
 		__public_key = serialization.load_ssh_public_key(fp.read().encode())
 
 
@@ -79,7 +79,7 @@ def decode_user_token(token: str) -> dict:
 			key=__public_key,
 			algorithms=['RS256']
 		)
-	except (jwt.ExpiredSignatureError, jwt.InvalidTokenError) as e:
+	except (jwt.ExpiredSignatureError, jwt.InvalidTokenError, jwt.InvalidSignatureError) as e:
 		raise InvalidJWTError from e
 
 

--- a/run.sh
+++ b/run.sh
@@ -87,12 +87,20 @@ fi
 	echo '}'
 } >site/config/sitemap.json
 
-#Generate VAPIDs
-if [ ! -e data/public_key.txt ]; then
-	openssl ecparam -name prime256v1 -genkey -noout -out data/vapid_private.pem
-	openssl ec -in data/vapid_private.pem -outform DER | tail -c +8 | head -c 32 | base64 | tr -d '=' | tr '/+' '_-' >data/private_key.txt
-	openssl ec -in data/vapid_private.pem -pubout -outform DER | tail -c 65 | base64 | tr -d '=' | tr '/+' '_-' >data/public_key.txt
-	rm -f data/vapid_private.pem
+# Make secrets dir
+mkdir -p data/secrets
+
+#Generate VAPID public and private key (for notifications)
+if [ ! -e data/secrets/public_key.txt ]; then
+	openssl ecparam -name prime256v1 -genkey -noout -out data/secrets/vapid_private.pem
+	openssl ec -in data/secrets/vapid_private.pem -outform DER | tail -c +8 | head -c 32 | base64 | tr -d '=' | tr '/+' '_-' >data/secrets/private_key.txt
+	openssl ec -in data/secrets/vapid_private.pem -pubout -outform DER | tail -c 65 | base64 | tr -d '=' | tr '/+' '_-' >data/secrets/public_key.txt
+	rm -f data/secrets/vapid_private.pem
+fi
+
+#Generate RSA public and private key (for JWTs)
+if [ ! -e data/secrets/id_rsa.pub ]; then
+	ssh-keygen -t rsa -f data/secrets/id_rsa -N ''
 fi
 
 #Make sure all dependencies are up to date

--- a/site/js/api.js
+++ b/site/js/api.js
@@ -454,6 +454,13 @@ api.handle_query_failure = async (res) => {
 		res.errors = (await res.json()).errors
 		console.error('API ERROR:', res.errors)
 		show_api_errors(res)
+
+		// If the JWT has become invalidated/corrupted/otherwise unreadable, just logout.
+		// In that case, it will just result in ALL api calls failing!
+		if (res?.errors?.[0]?.message === 'Invalid JWT') {
+			alert('Your session token is invalid, likely due to recent security updates (or possibly corrupted session data?).\n\nYou will need to log in again to generate a new (valid) token.')
+			api.logout()
+		}
 	}
 	else {
 		console.log('Token expired, logging out.')


### PR DESCRIPTION
1. Move secret location to more descriptive directory.
2. Don't rely on ssh setup to have RSA keys; generate our own instead.
3. If a user's JWT becomes invalid, log them out so they don't get stuck forever.